### PR TITLE
cleanup procs

### DIFF
--- a/lib/fast_cache/cache.rb
+++ b/lib/fast_cache/cache.rb
@@ -201,8 +201,8 @@ module FastCache
     end
 
     def shrink_if_needed
-      if @data.length > @max_size
-        entry = delete(@data.shift)
+      while @data.length > @max_size
+        entry = @data.shift.last
         @expires_at.delete(entry)
       end
     end

--- a/lib/fast_cache/cache.rb
+++ b/lib/fast_cache/cache.rb
@@ -39,6 +39,7 @@ module FastCache
       @op_count = 0
       @data = {}
       @expires_at = {}
+      @cleanup = Proc.new if block_given?
     end
 
     # Retrieves a value from the cache, if available and not expired, or
@@ -84,6 +85,7 @@ module FastCache
       entry = @data.delete(key)
       if entry
         @expires_at.delete(entry)
+        @cleanup.call(entry.value) if @cleanup
         entry.value
       else
         nil
@@ -103,6 +105,7 @@ module FastCache
     #
     # @return [self]
     def clear
+      @data.values.map(&:value).map(&@cleanup) if @cleanup
       @data.clear
       @expires_at.clear
       self
@@ -176,6 +179,7 @@ module FastCache
       if found
         if entry.expires_at <= t
           @expires_at.delete(entry)
+          @cleanup.call(entry.value) if @cleanup
           return false, nil
         else
           @data[key] = entry
@@ -194,7 +198,9 @@ module FastCache
     end
 
     def store_entry(key, entry)
-      @data.delete(key)
+      found = true
+      old_entry = @data.delete(key) { found = false }
+      @cleanup.call(old_entry.value) if @cleanup && found
       @data[key] = entry
       @expires_at[entry] = key
       shrink_if_needed
@@ -204,6 +210,7 @@ module FastCache
       while @data.length > @max_size
         entry = @data.shift.last
         @expires_at.delete(entry)
+        @cleanup.call(entry.value) if @cleanup
       end
     end
 
@@ -212,7 +219,8 @@ module FastCache
         while (key_value_pair = @expires_at.first) &&
             (entry = key_value_pair.first).expires_at <= t
           key = @expires_at.delete(entry)
-          @data.delete(key)
+          entry = @data.delete(key)
+          @cleanup.call(entry.value) if @cleanup
         end
       end
     end

--- a/spec/lib/fast_cache/cache_spec.rb
+++ b/spec/lib/fast_cache/cache_spec.rb
@@ -15,14 +15,19 @@ describe FastCache::Cache do
     end
   end
 
-  context 'non-empty cache' do
+  shared_context :non_empty_cache do
+    let(:cache) { described_class.new(3, 60, 1) }
     before do
-      @cache = described_class.new(3, 60, 1)
+      @cache = cache
       @cache[:a] = 1
       @cache[:b] = 2
       @cache[:c] = 3
     end
     subject { @cache }
+  end
+
+  context 'non-empty cache' do
+    include_context :non_empty_cache
 
     its(:empty?) { should be_false }
     its(:length) { should eq 3 }
@@ -110,6 +115,42 @@ describe FastCache::Cache do
         subject[:c].should be_nil
         subject[:d].should eq 4
         subject[:e].should eq 6
+      end
+    end
+
+    describe 'cleanup block' do
+      let(:cleanups) { [] }
+      let(:ttl) { 60 }
+      let(:cache) { described_class.new(3, ttl, 1) do |obj|
+        cleanups << obj
+      end }
+      it 'is called when the cache is cleared' do
+        subject.clear
+        cleanups.should =~ [1,2,3]
+      end
+      it 'is called when an item is deleted' do
+        subject.delete(:a).should eq 1
+        cleanups.should =~ [1]
+      end
+      it 'is called when an existing item is replaced' do
+        subject[:a] = 11
+        cleanups.should =~ [1]
+      end
+      it 'is called when an item is removed when full' do
+        subject[:d] = 4
+        cleanups.should =~ [1]
+      end
+
+      context 'with immediate expiration' do
+        let(:ttl) { 0 }
+        it 'is called when items are expired' do
+          subject.expire!
+          cleanups.should =~ [1,2,3]
+        end
+        it 'is called when item access triggers expiration' do
+          subject[:a].should be_nil
+          cleanups.should =~ [1,2,3]
+        end
       end
     end
   end


### PR DESCRIPTION
This adds support for a block to be passed to `FastCache::Cache.new`, which will be called anytime an entry is removed from the cache for any reason.
